### PR TITLE
feat: add user config file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ packages = find:
 include_package_data = True
 install_requires =
     click
+    importlib-resources
     platformdirs
 
 [options.packages.find]

--- a/src/weather_uk/cli.py
+++ b/src/weather_uk/cli.py
@@ -1,6 +1,15 @@
-import platformdirs
+import click
+
+from weather_uk.config import setup_config_if_none_exists, update_config
 
 
+@click.group()
 def main():
-    appname = "weather-uk"
-    print(platformdirs.user_config_dir(appname))
+    setup_config_if_none_exists()
+
+
+@main.command()
+@click.option("--apikey", help="Your Met Office Datapoint API key")
+def config(apikey):
+    if apikey:
+        update_config(apikey)

--- a/src/weather_uk/config.py
+++ b/src/weather_uk/config.py
@@ -1,0 +1,45 @@
+import shutil
+from configparser import ConfigParser
+from pathlib import Path
+
+import platformdirs
+from importlib_resources import files
+
+APPNAME: str = "weather-uk"
+
+CONFIG_PATH: Path = platformdirs.user_config_path(APPNAME)
+CONFIG_FILENAME = f"{APPNAME}.cfg"
+
+CONFIG_TEMPLATE = files("weather_uk.config_template").joinpath(CONFIG_FILENAME)
+
+
+def setup_config_if_none_exists(config_path: Path = CONFIG_PATH) -> None:
+    if not config_path.is_dir():
+        config_path.mkdir(parents=True, exist_ok=True)
+        try:
+            shutil.copy(CONFIG_TEMPLATE, config_path)
+        except PermissionError:
+            msg = (
+                f"Error creating config file at: {config_path}  "
+                "Permission is denied."
+            )
+            print(msg)
+
+
+def update_config(apikey: str, config_path: Path = CONFIG_PATH):
+    cfgparser = ConfigParser()
+    config_file = config_path / CONFIG_FILENAME
+    cfgparser.read(config_file)
+
+    try:
+        auth = cfgparser["auth"]
+        auth["apikey"] = apikey
+    except KeyError as e:
+        msg = (
+            f"Error detected in config file: {config_file}  "
+            f"Missing expected {e} entry."
+        )
+        print(msg)
+
+    with open(config_file, "wt") as f:
+        cfgparser.write(f)

--- a/src/weather_uk/config_template/weather-uk.cfg
+++ b/src/weather_uk/config_template/weather-uk.cfg
@@ -1,0 +1,2 @@
+[auth]
+apikey =

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,37 @@
+import filecmp
+from configparser import ConfigParser
+from pathlib import Path
+
+import pytest
+
+from weather_uk.config import (
+    CONFIG_TEMPLATE,
+    setup_config_if_none_exists,
+    update_config,
+)
+
+
+@pytest.fixture
+def mock_config_path(tmp_path):
+    p = tmp_path / "weather-uk"
+    return p
+
+
+def test_setup_config_if_none_exists(mock_config_path):
+    setup_config_if_none_exists(mock_config_path)
+    config_file = Path(mock_config_path / "weather-uk.cfg")
+    assert config_file.is_file()
+    assert config_file.parent.name == "weather-uk"
+    assert filecmp.cmp(CONFIG_TEMPLATE, config_file, shallow=False) is True
+
+
+def test_update_config(mock_config_path):
+    setup_config_if_none_exists(mock_config_path)
+    update_config(apikey="metofficeapikey", config_path=mock_config_path)
+
+    cfgparser = ConfigParser()
+    config_file = Path(mock_config_path) / "weather-uk.cfg"
+    cfgparser.read(config_file)
+    auth = cfgparser["auth"]
+    assert config_file.is_file()
+    assert auth["apikey"] == "metofficeapikey"


### PR DESCRIPTION
### Description

Feature for a config file to store the user's Met Office DataPoint API key and eventually other preferences. 

This `weather-uk.cfg` file is stored in the the appropriate user config directory as determined by [platformdirs](https://pypi.org/project/platformdirs/).

### Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
