### PR TITLE
feat: API requests to Met Office DataPoint

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ install_requires =
     click
     importlib-resources
     platformdirs
+    requests
 
 [options.packages.find]
 where = src
@@ -37,3 +38,4 @@ dev =
     mypy
     pytest
     pytest-cov
+    responses

--- a/src/weather_uk/api_requests.py
+++ b/src/weather_uk/api_requests.py
@@ -1,0 +1,39 @@
+import requests
+
+""" Met Office DataPoint API reference guide:
+https://www.metoffice.gov.uk/services/data/datapoint/api-reference
+"""
+
+BASE_URL: str = "http://datapoint.metoffice.gov.uk/public/data"
+
+
+def requests_adapter(url: str):
+    try:
+        resp = requests.get(url, timeout=5)
+        resp.raise_for_status()
+        data = resp.json()
+        return data
+    except requests.exceptions.HTTPError as http_err:
+        print(http_err)
+    except requests.exceptions.ConnectionError as cxn_err:
+        print(cxn_err)
+    except requests.exceptions.Timeout as timeout_err:
+        print(timeout_err)
+    except requests.exceptions.RequestException as req_err:
+        print(req_err)
+
+
+def create_url_from_endpoint(endpoint: str, apikey: str) -> str:
+    key_prefix: str = "&" if "?" in endpoint else "?"
+    url: str = f"{BASE_URL}/{endpoint}{key_prefix}key={apikey}"
+    return url
+
+
+def create_forecast_endpoint(location_id: str, time_step: str) -> str:
+    endpoint = f"val/wxfcs/all/json/{location_id}?res={time_step}"
+    return endpoint
+
+
+def get_data(endpoint: str, apikey: str, adapter=requests_adapter):
+    url = create_url_from_endpoint(endpoint, apikey)
+    return adapter(url)

--- a/tests/resources/mock_forecast.json
+++ b/tests/resources/mock_forecast.json
@@ -1,0 +1,205 @@
+{
+  "SiteRep": {
+    "Wx": {
+      "Param": [
+        {
+          "name": "FDm",
+          "units": "C",
+          "$": "Feels Like Day Maximum Temperature"
+        },
+        {
+          "name": "FNm",
+          "units": "C",
+          "$": "Feels Like Night Minimum Temperature"
+        },
+        { "name": "Dm", "units": "C", "$": "Day Maximum Temperature" },
+        { "name": "Nm", "units": "C", "$": "Night Minimum Temperature" },
+        { "name": "Gn", "units": "mph", "$": "Wind Gust Noon" },
+        { "name": "Gm", "units": "mph", "$": "Wind Gust Midnight" },
+        { "name": "Hn", "units": "%", "$": "Screen Relative Humidity Noon" },
+        {
+          "name": "Hm",
+          "units": "%",
+          "$": "Screen Relative Humidity Midnight"
+        },
+        { "name": "V", "units": "", "$": "Visibility" },
+        { "name": "D", "units": "compass", "$": "Wind Direction" },
+        { "name": "S", "units": "mph", "$": "Wind Speed" },
+        { "name": "U", "units": "", "$": "Max UV Index" },
+        { "name": "W", "units": "", "$": "Weather Type" },
+        { "name": "PPd", "units": "%", "$": "Precipitation Probability Day" },
+        { "name": "PPn", "units": "%", "$": "Precipitation Probability Night" }
+      ]
+    },
+    "DV": {
+      "dataDate": "2022-11-04T17:00:00Z",
+      "type": "Forecast",
+      "Location": {
+        "i": "3840",
+        "lat": "50.86",
+        "lon": "-3.239",
+        "name": "DUNKESWELL AERODROME",
+        "country": "ENGLAND",
+        "continent": "EUROPE",
+        "elevation": "252.0",
+        "Period": [
+          {
+            "type": "Day",
+            "value": "2022-11-04Z",
+            "Rep": [
+              {
+                "D": "NW",
+                "Gn": "22",
+                "Hn": "71",
+                "PPd": "0",
+                "S": "11",
+                "V": "VG",
+                "Dm": "11",
+                "FDm": "10",
+                "W": "3",
+                "U": "1",
+                "$": "Day"
+              },
+              {
+                "D": "SSW",
+                "Gm": "16",
+                "Hm": "87",
+                "PPn": "91",
+                "S": "7",
+                "V": "VG",
+                "Nm": "6",
+                "FNm": "4",
+                "W": "9",
+                "$": "Night"
+              }
+            ]
+          },
+          {
+            "type": "Day",
+            "value": "2022-11-05Z",
+            "Rep": [
+              {
+                "D": "SSW",
+                "Gn": "31",
+                "Hn": "97",
+                "PPd": "93",
+                "S": "18",
+                "V": "PO",
+                "Dm": "13",
+                "FDm": "9",
+                "W": "12",
+                "U": "1",
+                "$": "Day"
+              },
+              {
+                "D": "SSW",
+                "Gm": "18",
+                "Hm": "98",
+                "PPn": "49",
+                "S": "9",
+                "V": "MO",
+                "Nm": "9",
+                "FNm": "7",
+                "W": "7",
+                "$": "Night"
+              }
+            ]
+          },
+          {
+            "type": "Day",
+            "value": "2022-11-06Z",
+            "Rep": [
+              {
+                "D": "WSW",
+                "Gn": "25",
+                "Hn": "89",
+                "PPd": "68",
+                "S": "13",
+                "V": "VG",
+                "Dm": "12",
+                "FDm": "8",
+                "W": "14",
+                "U": "1",
+                "$": "Day"
+              },
+              {
+                "D": "SW",
+                "Gm": "27",
+                "Hm": "91",
+                "PPn": "48",
+                "S": "13",
+                "V": "GO",
+                "Nm": "9",
+                "FNm": "6",
+                "W": "7",
+                "$": "Night"
+              }
+            ]
+          },
+          {
+            "type": "Day",
+            "value": "2022-11-07Z",
+            "Rep": [
+              {
+                "D": "SSW",
+                "Gn": "38",
+                "Hn": "89",
+                "PPd": "47",
+                "S": "20",
+                "V": "GO",
+                "Dm": "13",
+                "FDm": "9",
+                "W": "12",
+                "U": "1",
+                "$": "Day"
+              },
+              {
+                "D": "S",
+                "Gm": "43",
+                "Hm": "92",
+                "PPn": "83",
+                "S": "20",
+                "V": "MO",
+                "Nm": "10",
+                "FNm": "7",
+                "W": "15",
+                "$": "Night"
+              }
+            ]
+          },
+          {
+            "type": "Day",
+            "value": "2022-11-08Z",
+            "Rep": [
+              {
+                "D": "SW",
+                "Gn": "36",
+                "Hn": "82",
+                "PPd": "59",
+                "S": "18",
+                "V": "VG",
+                "Dm": "13",
+                "FDm": "9",
+                "W": "29",
+                "U": "1",
+                "$": "Day"
+              },
+              {
+                "D": "SW",
+                "Gm": "22",
+                "Hm": "92",
+                "PPn": "36",
+                "S": "11",
+                "V": "VG",
+                "Nm": "9",
+                "FNm": "5",
+                "W": "9",
+                "$": "Night"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/test_api_requests.py
+++ b/tests/test_api_requests.py
@@ -1,0 +1,65 @@
+import json
+from http import HTTPStatus
+
+import pytest
+import responses
+
+from weather_uk.api_requests import (
+    create_forecast_endpoint,
+    create_url_from_endpoint,
+    get_data,
+    requests_adapter,
+)
+
+
+@pytest.fixture()
+def mock_forecast_data():
+    with open("tests/resources/mock_forecast.json") as f:
+        return json.load(f)
+
+
+def test_create_url_from_endpoint():
+    url = create_url_from_endpoint(
+        endpoint="val/wxfcs/all/json/3840?res=3hourly",
+        apikey="01234567-89ab-cdef-0123-456789abcdef",
+    )
+    assert url == (
+        "http://datapoint.metoffice.gov.uk/public/data/"
+        "val/wxfcs/all/json/3840?res=3hourly"
+        "&key=01234567-89ab-cdef-0123-456789abcdef"
+    )
+
+
+def test_create_forecast_endpoint():
+    location_id = "3840"
+    time_step = "3hourly"
+    endpoint = create_forecast_endpoint(location_id, time_step)
+    assert endpoint == "val/wxfcs/all/json/3840?res=3hourly"
+
+
+@responses.activate
+def test_get_data_using_adapter(mock_forecast_data):
+    def mock_adapter(url):
+        return mock_forecast_data
+
+    endpoint = "val/wxfcs/all/json/3840?res=3hourly"
+    apikey = "01234567-89ab-cdef-0123-456789abcdef"
+    data = get_data(endpoint, apikey, adapter=mock_adapter)
+    assert data == mock_forecast_data
+
+
+@responses.activate
+def test_requests_adapter(mock_forecast_data):
+    url = (
+        "http://datapoint.metoffice.gov.uk/public/data/"
+        "val/wxfcs/all/json/3840?res=3hourly"
+        "&key=01234567-89ab-cdef-0123-456789abcdef"
+    )
+    responses.add(
+        responses.GET,
+        url,
+        json=mock_forecast_data,
+        status=HTTPStatus.OK,
+    )
+    data = requests_adapter(url)
+    assert data == mock_forecast_data


### PR DESCRIPTION
### Description

Feature for the basic functionality of API requests to Met Office DataPoint, including creating forecast endpoints from a provided location ID.

This API requests functionality still needs to implemented into the CLI.

### How Has This Been Tested?

To avoid coupling the tests with the implementation, the code abstracts away the code that performs the API request using an adapter. Dependency injection is used to inject a mock adapter during test time. 

### Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
