### PR TITLE
feat(locations): haversine

### DIFF
--- a/src/weather_uk/locations.py
+++ b/src/weather_uk/locations.py
@@ -1,4 +1,7 @@
 from dataclasses import dataclass
+from math import asin, cos, radians, sin, sqrt
+
+AVG_EARTH_RADIUS_KM = 6371.0088  # https://en.wikipedia.org/wiki/Earth_radius
 
 
 @dataclass
@@ -6,13 +9,13 @@ class UserGeolocation:
     city: str
     region: str
     country: str
-    latitude: str
-    longitude: str
+    latitude: float
+    longitude: float
 
     @classmethod
     def from_dict(cls, data: dict):
         coordinates: str = data["loc"]
-        latitude, longitude = coordinates.split(",")
+        latitude, longitude = [float(x) for x in coordinates.split(",")]
         return cls(
             city=data["city"],
             region=data["region"],
@@ -20,3 +23,18 @@ class UserGeolocation:
             latitude=latitude,
             longitude=longitude,
         )
+
+
+def haversine(lat1: float, long1: float, lat2: float, long2: float) -> float:
+    """The haversine formula calculates the great-circle distance
+    between two points on the Earth surface
+    """
+    # convert all latitudes/longitudes from decimal degrees to radians
+    lat1, long1, lat2, long2 = map(radians, [lat1, long1, lat2, long2])
+    # calculate haversine
+    dlat = lat2 - lat1
+    dlong = long2 - long1
+    d = sin(dlat * 0.5) ** 2 + cos(lat1) * cos(lat2) * sin(dlong * 0.5) ** 2
+    c = 2 * asin(sqrt(d))
+
+    return AVG_EARTH_RADIUS_KM * c

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from weather_uk.locations import UserGeolocation
+from weather_uk.locations import UserGeolocation, haversine
 
 
 @pytest.fixture()
@@ -16,5 +16,17 @@ def test_user_geolocation_class(mock_ipinfo_data):
     assert user_geolocation.city == "London"
     assert user_geolocation.region == "England"
     assert user_geolocation.country == "GB"
-    assert user_geolocation.latitude == "51.5085"
-    assert user_geolocation.longitude == "-0.1257"
+    assert user_geolocation.latitude == 51.5085
+    assert user_geolocation.longitude == -0.1257
+
+
+def test_haversine():
+    """Test based on the distance between Lyon and Paris
+    example provided by https://github.com/mapado/haversine"""
+    lat1 = 45.7597
+    long1 = 4.8422
+    lat2 = 48.8567
+    long2 = 2.3508
+
+    distance = haversine(lat1, long1, lat2, long2)
+    assert distance == 392.2172595594006


### PR DESCRIPTION
### Description

Feature for haversine formula which calculates the great-circle distance between two points on the Earth surface.

This will be used to find the nearest Met Office Datapoint location from the user's geolocation.

Also improves the `UserGeolocation` class by converting the longitude/latitude from strings to floats. 

### Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
