### PR TITLE
feat(forecasts) add forecast weather dataclass

### DIFF
--- a/src/weather_uk/forecasts.py
+++ b/src/weather_uk/forecasts.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass
+
+from weather_uk.weather_type import WeatherType
+
+
+@dataclass
+class ForecastWeatherData:
+    weather_type: WeatherType
+    temp_c: float
+    temp_feels_like_c: float
+    precip_prob_pct: float
+    wind_speed_mph: float
+    wind_gust_mph: float
+    wind_direction: str
+    uv_idx: int
+    humidity_pct: float
+    visibility: str
+
+    @classmethod
+    def from_dict(cls, data: dict):
+        weather_type_code = int(data["W"])
+        weather_type = WeatherType(weather_type_code)
+        return cls(
+            weather_type=weather_type,
+            temp_c=float(data["T"]),
+            temp_feels_like_c=float(data["F"]),
+            precip_prob_pct=float(data["Pp"]),
+            wind_speed_mph=float(data["S"]),
+            wind_gust_mph=float(data["G"]),
+            wind_direction=data["D"],
+            uv_idx=int(data["U"]),
+            humidity_pct=float(data["H"]),
+            visibility=data["V"],
+        )

--- a/src/weather_uk/weather_type.py
+++ b/src/weather_uk/weather_type.py
@@ -1,0 +1,51 @@
+from enum import Enum, auto
+
+
+class WeatherType(Enum):
+    """Met Office DataPoint weather type codes:
+    https://www.metoffice.gov.uk/services/data/datapoint/code-definitions
+    """
+
+    CLEAR_NIGHT = 0
+    SUNNY_DAY = auto()
+    PARTLY_CLOUDY_NIGHT = auto()
+    PARTLY_CLOUDY_DAY = auto()
+    NOT_USED = auto()
+    MIST = auto()
+    FOG = auto()
+    CLOUDY = auto()
+    OVERCAST = auto()
+    LIGHT_RAIN_SHOWER_NIGHT = auto()
+    LIGHT_RAIN_SHOWER_DAY = auto()
+    DRIZZLE = auto()
+    LIGHT_RAIN = auto()
+    HEAVY_RAIN_SHOWER_NIGHT = auto()
+    HEAVY_RAIN_SHOWER_DAY = auto()
+    HEAVY_RAIN = auto()
+    SLEET_SHOWER_NIGHT = auto()
+    SLEET_SHOWER_DAY = auto()
+    SLEET = auto()
+    HAIL_SHOWER_NIGHT = auto()
+    HAIL_SHOWER_DAY = auto()
+    HAIL = auto()
+    LIGHT_SNOW_SHOWER_NIGHT = auto()
+    LIGHT_SNOW_SHOWER_DAY = auto()
+    LIGHT_SNOW = auto()
+    HEAVY_SNOW_SHOWER_NIGHT = auto()
+    HEAVY_SNOW_SHOWER_DAY = auto()
+    HEAVY_SNOW = auto()
+    THUNDER_SHOWER_NIGHT = auto()
+    THUNDER_SHOWER_DAY = auto()
+    THUNDER = auto()
+
+    def __str__(self) -> str:
+        description: str = self.name.replace("_", " ").capitalize()
+        substrs_to_replace: dict = {
+            " day": " (day)",
+            " night": "_night",
+        }
+        for key, value in substrs_to_replace.items():
+            if description != "Sunny day":
+                description = description.replace(key, value)
+
+        return description

--- a/tests/test_forecasts.py
+++ b/tests/test_forecasts.py
@@ -1,0 +1,29 @@
+import json
+
+import pytest
+
+from weather_uk.forecasts import ForecastWeatherData
+
+
+@pytest.fixture()
+def mock_forecast_data():
+    with open("tests/resources/mock_3hourly_forecast.json") as f:
+        return json.load(f)
+
+
+def test_forecast_weather_data(mock_forecast_data):
+    weather_location = mock_forecast_data["SiteRep"]["DV"]["Location"]
+    weather_period = weather_location["Period"]
+    weather_data = weather_period[0]["Rep"][0]
+    weather = ForecastWeatherData.from_dict(weather_data)
+
+    assert str(weather.weather_type) == "Heavy rain"
+    assert weather.temp_c == 9
+    assert weather.temp_feels_like_c == 7
+    assert weather.precip_prob_pct == 97
+    assert weather.wind_speed_mph == 9
+    assert weather.wind_gust_mph == 11
+    assert weather.wind_direction == "S"
+    assert weather.uv_idx == 0
+    assert weather.humidity_pct == 100
+    assert weather.visibility == "MO"

--- a/tests/test_weather_type.py
+++ b/tests/test_weather_type.py
@@ -1,0 +1,13 @@
+from weather_uk.weather_type import WeatherType
+
+
+def test_weather_type_sunny_day():
+    weather_type_code = 1
+    weather_type = WeatherType(weather_type_code)
+    assert str(weather_type) == "Sunny day"
+
+
+def test_weather_type_thunder_day():
+    weather_type_code = 29
+    weather_type = WeatherType(weather_type_code)
+    assert str(weather_type) == "Thunder shower (day)"


### PR DESCRIPTION
### Description

Feature for `ForecastWeatherData` dataclass to parse the forecast data for a specific location/period from Met Office DataPoint.

The Met Office DataPoint forecast data uses integer codes to describe the different weather types (e.g. 1 = Sunny day). These are parsed using the `WeatherType` enum class.    

See: https://www.metoffice.gov.uk/services/data/datapoint/code-definitions

### Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
