### PR TITLE
feat(weather): shorten weather strings

### DIFF
--- a/src/weather_uk/weather_type.py
+++ b/src/weather_uk/weather_type.py
@@ -41,11 +41,11 @@ class WeatherType(Enum):
     def __str__(self) -> str:
         description: str = self.name.replace("_", " ").capitalize()
         substrs_to_replace: dict = {
-            " day": " (day)",
-            " night": "_night",
+            " day": "",
+            " night": "",
         }
         for key, value in substrs_to_replace.items():
-            if description != "Sunny day":
+            if description not in ("Sunny day", "Clear night"):
                 description = description.replace(key, value)
 
         return description

--- a/tests/test_weather_type.py
+++ b/tests/test_weather_type.py
@@ -10,4 +10,16 @@ def test_weather_type_sunny_day():
 def test_weather_type_thunder_day():
     weather_type_code = 29
     weather_type = WeatherType(weather_type_code)
-    assert str(weather_type) == "Thunder shower (day)"
+    assert str(weather_type) == "Thunder shower"
+
+
+def test_weather_type_clear_night():
+    weather_type_code = 0
+    weather_type = WeatherType(weather_type_code)
+    assert str(weather_type) == "Clear night"
+
+
+def test_weather_type_thunder_night():
+    weather_type_code = 28
+    weather_type = WeatherType(weather_type_code)
+    assert str(weather_type) == "Thunder shower"


### PR DESCRIPTION
### Description

Feature to shorten the weather type strings, removing "day" or "night" as unnecessary for this application. The exceptions are "Sunny day" and "Clear night".

### Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
