### PR TITLE
build: update dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,8 +19,8 @@ packages = find:
 include_package_data = True
 install_requires =
     requests
-    textual >= 0.19.0
-    textual-autocomplete >= 2.1.0b0
+    textual >= 0.77.0
+    textual-autocomplete == 2.1.0b0
     platformdirs
 
 [options.packages.find]
@@ -39,4 +39,4 @@ dev =
     pytest
     pytest-cov
     types-requests
-    textual[dev]
+    textual-dev

--- a/src/weather_uk/app/app.py
+++ b/src/weather_uk/app/app.py
@@ -11,13 +11,14 @@ from weather_uk.ports.weather_api import AbstractWeatherApi
 class WeatherUkApp(App):
     CSS_PATH = "weather-uk.css"
     SCREENS = {
-        "welcome": WelcomeScreen(),
-        "locations": LocationsScreen(),
-        "forecast": ForecastScreen(),
+        "welcome": WelcomeScreen,
+        "locations": LocationsScreen,
+        "forecast": ForecastScreen,
     }
     BINDINGS = [
         ("q", "quit", "Quit"),
     ]
+    ENABLE_COMMAND_PALETTE = False
 
     def on_mount(self) -> None:
         self._user_config: config.UserConfig = config.load_config()


### PR DESCRIPTION
- Update `textual` from now very outdated version!
- Pin `textual-autocomplete` to v2 (v3 is currently unstable and undocumented)
